### PR TITLE
Allow self-resolution for app, addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Resolve paths within dependent packages, with additional awareness of:
 
+  - ember apps
   - ember in-repo addons
   - the pre-embroider (v1) ember addon format
 
@@ -22,6 +23,12 @@ resolveCliAware('../foo', {
 }) // => /some/absolute/foo
 
 
+// for an ember app at /some/absolute/path
+resolveCliAware('my-ember-app-name/foo', {
+  basedir: '/some/absolute/path'
+}) // => /some/absolute/path/app/foo
+
+
 
 // with a v1 ember-addon configured as follows
 {
@@ -40,7 +47,7 @@ resolveCliAware('my-dependency/some/path', {
 
   // you can optionally pass pkg and pkgRoot for resolving package dependencies
   // if these are absent, package.json will be found by walking up the tree
-  from basedir
+  // from basedir
   pkg: myAlreadyReadPackageJson,
   pkgRoot: '/path/to/project'
 }) // => /some/absolute/foo
@@ -55,3 +62,17 @@ try {
 
 ```
 
+## Limitations
+
+- Non-ember npm dependencies are not supported.  It is assumed all resolutions one of:
+   - classic ember apps
+   - classic ember addons
+   - v2 ember addons
+
+- No support for app namespace merging: so files in an addon's `app` directory will not be resolved.  Similarly, `${my-addon}/test-support` will not be resolved as being merged to `${my-app}/tests`.
+
+- No support for path conflict resolution.  This is unlikely to affect anybody, but if you have an Ember app with `my-app/app/tests/foo`, `my-app/tests/foo` will not resolve to this file, but instead only look for `my-app/tests/foo`
+
+- No support for customized `this.treePaths` in addons.
+
+- "main" imports are not supported (i.e. imports without paths)

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -31,37 +31,32 @@ fragment Apple on Person {
     addon.pkg['ember-addon'] = { version: 2 };
     addon.files = {
       '_person.graphql': `
-fragment Apple on Person {
-  other
-  person
-  fragment
-}`,
+        fragment Apple on Person {
+          other
+          person
+          fragment
+        }`,
     };
   });
-
-  project.pkg['ember-addon'] = {
-    configPath: 'ember-config',
-    paths: ['./in-repo-addons/the-in-repo-addon', './in-repo-addons/the-v2-in-repo-addon'],
-  };
 
   const myAddon = project.addDependency('my-addon', '0.0.1', addon => {
     addon.pkg.keywords = ['ember-addon'];
 
     addon.files['addon'] = {
       '_person.graphql': `
-fragment Apple on Person {
-  id
-  name
-}`,
+        fragment Apple on Person {
+          id
+          name
+        }`,
     };
 
     addon.addDependency('nested-dep', '0.0.1', nested => {
       nested.pkg.keywords = ['ember-addon'];
       nested.files['addon'] = {
         '_person.graphql': `
-fragment AppleApple on Person {
-  likesApples
-}`,
+          fragment AppleApple on Person {
+            likesApples
+          }`,
       };
     });
 
@@ -69,9 +64,9 @@ fragment AppleApple on Person {
       nested.pkg.keywords = ['ember-addon'];
       nested.files['addon'] = {
         '_person.graphql': `
-fragment AppleApple on Person {
-  likesApples
-}`,
+          fragment AppleApple on Person {
+            likesApples
+          }`,
       };
     });
   });
@@ -81,36 +76,10 @@ fragment AppleApple on Person {
     addon.pkg['ember-addon'] = { version: 2 };
 
     addon.files['_person.graphql'] = `
-fragment Apple on Person {
-  id
-  name
-}`;
-  });
-
-  project.addDependency('my-nested-dep-addon', '0.0.1', addon => {
-    addon.pkg.keywords = ['ember-addon'];
-    addon.files['addon'] = {
-      '_person.graphql': `
-
-#import "nested-dep/path/_fragment.graphql"
-fragment Apple on Person {
-  id
-  name
-  ...NestedFragment
-}`,
-    };
-    addon.addDependency('nested-dep', '0.0.1', nestedDep => {
-      addon.pkg.keywords = ['ember-addon'];
-      addon.files['addon'] = {
-        path: {
-          '_fragment.graphql': `
-fragment NestedFragment on Person {
-  id
-}
-`,
-        },
-      };
-    });
+      fragment Apple on Person {
+        id
+        name
+      }`;
   });
 
   // test to ensure in-repo > dep


### PR DESCRIPTION
- [x] update docs
  - re ember context hard assumption
  - explicitly no support for conflicts like app/tests
  - explicitly no support for app namespace merging
- [x] update app detection (keywords not include "ember-addon")
- [x] update app paths
  - `resolve('my-app/tests/helpers/foo') // => my-app/tests/helpers/foo`
  - `resolve('my-app/foo') // => my-app/app/foo`
- [x] update addon paths
  - `addon-test-support`

---

- Allow self-resolution for apps and addons
- Make test graphql queries more readable.

This is mainly useful so tests can import from absolute paths

my-app/tests/foo.graphql
import "my-app/components/_fragment.graphql"
// => /path/to/my-app/app/components/_fragment.graphql

my-addon/tests/foo.graphql
import "my-addon/comopnents/_fragment.graphql"
// => /path/to/my-addon/addon/components/_fragment.graphql