### PR TITLE
chore: bump Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['10', '12', '14']
+        node: ['16', '18', '20']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Bumping to Maintenance (16), LTS (18) and Active (20).
