### PR TITLE
Add `throwOnMissingFile` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,9 +180,10 @@ function resolveIdentifier(identifier, options = {}) {
  *  @param {string} options.basedir - The dirname to resolve relative to: this should be the dirname of the file that is referencing `identifier`
  *  @param {string} [options.pkg] - The package.json to use for determining what identifiers are valid dependencies.  If present, `options.pkgRoot` must also be specified.  If absent, `package.json` will be discovered by searching `options.basedir` by walking up the directory tree.
  *  @param {string} [options.pkgRoot] - The directory that contains the `package.json` file whose contents were passed in as `options.pkg`.  Used as the search location for package dependencies (e.g. the location from which relative entries in `ember-addon.paths` will be resolved).  If present, `options.pkg` must also be specified.  If absent, it will default to the dirname in which `package.json` was discovered when determining the default value for `options.pkg`.
- */
-module.exports = function resolve(identifier, options = {}) {
-  const { basedir, pkg, pkgRoot } = options;
+ *  @param {boolean} [options.throwOnMissingFile] - Defaults to true. If false, it returns the computed path even if the file does not exist. 
+*/
+ module.exports = function resolve(identifier, options = {}) {
+  const { basedir, pkg, pkgRoot, throwOnMissingFile = true } = options;
   if (typeof basedir !== 'string') {
     throw new Error('ember-cli-addon-resolver: options.basedir is required');
   }
@@ -194,7 +195,7 @@ module.exports = function resolve(identifier, options = {}) {
   }
 
   let result = resolveIdentifier(identifier, options);
-  if (result === null || !fs.existsSync(result)) {
+  if (result === null || (throwOnMissingFile !== false && !fs.existsSync(result))) {
     let err = new Error(`ENOENT: Unable to resolve import ${identifier} from ${options.basedir}`);
     err.code = 'MODULE_NOT_FOUND';
     throw err;

--- a/parse-identifier.js
+++ b/parse-identifier.js
@@ -30,4 +30,4 @@ module.exports = function parseIdentifier(identifier) {
 };
 
 // exported for testing
-module.exports._IdentifierRegexp = IdentifierRegexp;
+module.exports.IdentifierRegexp = IdentifierRegexp;

--- a/parse-identifier.js
+++ b/parse-identifier.js
@@ -30,4 +30,4 @@ module.exports = function parseIdentifier(identifier) {
 };
 
 // exported for testing
-module.exports.IdentifierRegexp = IdentifierRegexp;
+module.exports._IdentifierRegexp = IdentifierRegexp;

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -320,6 +320,15 @@ describe('ember-cli-addon-resolver', function () {
     }
   });
 
+  it('does not throw `Unable to resolve import` if `throwOnMissingFile` is false', function () {
+    expect(
+      resolve('the-in-repo-addon/index.js', {
+        basedir: project.baseDir,
+        throwOnMissingFile: false
+      }),
+    ).to.eql(path.join(project.baseDir, '/in-repo-addons/the-in-repo-addon/addon/index.js'));
+  });
+
   it('resolves in-repo v1 addons from the root', function () {
     expect(
       resolve('the-in-repo-addon/_person.graphql', {


### PR DESCRIPTION
Add `throwOnMissingFile` option:
 - With this, when `fs.existsSync` returns false simply because the file extension (.js) for example is incorrect, users can still access the computed path and modify it as they see fit (try to resolve the file with a different file extension for example)
 